### PR TITLE
add app provider

### DIFF
--- a/src/Home/ui/pages/HomePage.tsx
+++ b/src/Home/ui/pages/HomePage.tsx
@@ -17,7 +17,6 @@ export function Component() {
     <APIProvider apiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY}>
       <AppLayout>
         <AppSidebar
-          isSidebarOpen={true}
           handleSearch={() => {}}
           handleSelectBusiness={() => {}}
           filteredBusinesses={businesses}

--- a/src/Shared/ui/context/AppContext.tsx
+++ b/src/Shared/ui/context/AppContext.tsx
@@ -1,0 +1,20 @@
+import type { PropsWithChildren } from 'react'
+
+import { createGenericContext } from '@/Shared/ui/createGenericContext'
+import {
+  type IUseAppController,
+  useAppController,
+} from '@/Shared/ui/hooks/useAppController'
+
+type Context = IUseAppController
+
+type Props = PropsWithChildren
+
+const [useApp, StateContextProvider] = createGenericContext<Context>()
+
+const AppProvider = ({ children }: Props) => {
+  const controller = useAppController()
+  return <StateContextProvider value={{ ...controller }}>{children}</StateContextProvider>
+}
+
+export { AppProvider, useApp }

--- a/src/Shared/ui/hooks/useAppController.ts
+++ b/src/Shared/ui/hooks/useAppController.ts
@@ -1,0 +1,19 @@
+import { useState } from 'react'
+
+export interface IUseAppController {
+  isSidebarOpen: boolean
+  toggleSidebar: () => void
+}
+
+export const useAppController = (): IUseAppController => {
+  const [isSidebarOpen, setIsSidebarOpen] = useState<boolean>(true)
+
+  const toggleSidebar = () => {
+    setIsSidebarOpen(!isSidebarOpen)
+  }
+
+  return {
+    isSidebarOpen,
+    toggleSidebar,
+  }
+}

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,13 +1,11 @@
 import { Menu, X } from 'lucide-react'
-import { type PropsWithChildren, useState } from 'react'
+import { type PropsWithChildren } from 'react'
 
+import { useApp } from '@/Shared/ui/context/AppContext'
 import { Button } from '@/components/ui/button'
 
 export const AppLayout = ({ children }: PropsWithChildren) => {
-  const [isSidebarOpen, setIsSidebarOpen] = useState<boolean>(true)
-  const toggleSidebar = () => {
-    setIsSidebarOpen(!isSidebarOpen)
-  }
+  const { toggleSidebar, isSidebarOpen } = useApp()
 
   return (
     <div className="flex h-screen flex-col overflow-hidden">

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,9 +1,9 @@
 import type { Business } from '@/Home/domain/business'
+import { useApp } from '@/Shared/ui/context/AppContext'
 import BusinessListItem from '@/components/BusinessListItem'
 import { SearchBar } from '@/components/SearchBar'
 
 interface AppSidebarProps {
-  isSidebarOpen: boolean
   handleSearch: (query: string) => void
   handleSelectBusiness: (business: Business) => void
   filteredBusinesses: Business[]
@@ -12,13 +12,14 @@ interface AppSidebarProps {
 }
 
 export const AppSidebar = ({
-  isSidebarOpen,
   handleSearch,
   handleSelectBusiness,
   filteredBusinesses,
   selectedBusiness,
   searchQuery,
 }: AppSidebarProps) => {
+  const { isSidebarOpen } = useApp()
+
   return (
     <div
       className={` ${isSidebarOpen ? 'translate-x-0' : '-translate-x-full'} border-border bg-background absolute z-10 flex h-[calc(100%-56px)] w-full flex-col border-r transition-transform duration-300 ease-in-out md:relative md:h-full md:w-96 md:translate-x-0`}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider, createBrowserRouter } from 'react-router'
 
+import { AppProvider } from '@/Shared/ui/context/AppContext'
 import '@/globals.css'
 import { routes } from '@/router/routes'
 
@@ -14,9 +15,11 @@ const router = createBrowserRouter(routes)
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-      <ReactQueryDevtools initialIsOpen={false} />
-    </QueryClientProvider>
+    <AppProvider>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+        <ReactQueryDevtools initialIsOpen={false} />
+      </QueryClientProvider>
+    </AppProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
This pull request introduces a new context-based state management approach for handling the sidebar's open/close state across the application. The changes centralize the sidebar state logic into a reusable context (`AppContext`) and remove redundant state management from individual components.

### State Management Refactor:

* **Created a new `AppContext` for global state management**:
  - Added `AppProvider` and `useApp` in `src/Shared/ui/context/AppContext.tsx` to manage the sidebar state globally.
  - Implemented `useAppController` hook in `src/Shared/ui/hooks/useAppController.ts` to encapsulate the state logic for toggling the sidebar.

* **Integrated `AppContext` into the application**:
  - Wrapped the application with `AppProvider` in `src/main.tsx` to provide the context globally. [[1]](diffhunk://#diff-1cd8b18798a1a103bfe13bef54354c1f3a3bea29a31c8eea1a0c67a3a839b811R7) [[2]](diffhunk://#diff-1cd8b18798a1a103bfe13bef54354c1f3a3bea29a31c8eea1a0c67a3a839b811R18-R23)

### Component Updates:

* **Refactored `AppLayout` to use the new context**:
  - Removed local state management and replaced it with `useApp` for accessing `toggleSidebar` and `isSidebarOpen`.

* **Refactored `AppSidebar` to use the new context**:
  - Removed the `isSidebarOpen` prop and accessed it directly via `useApp`. Updated the component logic accordingly. [[1]](diffhunk://#diff-c20ed4ea1b04ac9d0cf52f7091af6d6acb852144b5e36ed7c496ac1afe8e03f0R2-L6) [[2]](diffhunk://#diff-c20ed4ea1b04ac9d0cf52f7091af6d6acb852144b5e36ed7c496ac1afe8e03f0L15-R22)

* **Removed unused `isSidebarOpen` prop from `HomePage`**:
  - Simplified the `AppSidebar` usage in `HomePage` by removing the `isSidebarOpen` prop.