### PR TITLE
Add global hydrator fallback

### DIFF
--- a/src/components/GlobalLoading.tsx
+++ b/src/components/GlobalLoading.tsx
@@ -1,0 +1,9 @@
+import { Loader } from 'lucide-react'
+
+export const GlobalLoading = () => {
+  return (
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/40">
+      <Loader className="h-12 w-12 animate-spin text-white" />
+    </div>
+  )
+}

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -1,10 +1,13 @@
 import type { RouteObject } from 'react-router'
 
+import { GlobalLoading } from '@/components/GlobalLoading'
+
 import { HOME } from '.'
 
 export const routes: RouteObject[] = [
   {
     path: HOME,
+    HydrateFallback: GlobalLoading,
     lazy: () => import('../Home/ui/pages/HomePage'),
   },
 ]


### PR DESCRIPTION
This pull request introduces a new global loading spinner component and integrates it into the routing system for a better user experience during lazy loading. Below are the key changes:

### New Component Addition:

* [`src/components/GlobalLoading.tsx`](diffhunk://#diff-d5c225c4cff99401b3a8e787e89d44210ff3b858dae772856b55054201df060dR1-R9): Added a new `GlobalLoading` component that displays a centered spinner with a semi-transparent background. This component uses the `Loader` icon from the `lucide-react` library.

### Routing System Update:

* [`src/router/routes.ts`](diffhunk://#diff-7241b3ad93bec4de280f994b6a95e85034757aeff28b8a33fe6dffb1c0ab77e8R3-R10): Integrated the `GlobalLoading` component as the `HydrateFallback` for the home route, ensuring a loading spinner is displayed while the `HomePage` component is lazily loaded.