### PR TITLE
Disable dark mode

### DIFF
--- a/src/variables.css
+++ b/src/variables.css
@@ -3,7 +3,7 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
+  color-scheme: light;
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the `src/variables.css` file by modifying the `color-scheme` property to only support the light mode, removing support for dark mode.

* [`src/variables.css`](diffhunk://#diff-1c5169658b42ded94b9a94de91aa11140360f581f4566088409782c4d5eccdb2L6-R6): Changed `color-scheme` from `light dark` to `light`, limiting the color scheme to light mode.