### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   node:
     name: Node ${{ matrix.node }}


### PR DESCRIPTION
Potential fix for [https://github.com/Runroom/edenred_test/security/code-scanning/2](https://github.com/Runroom/edenred_test/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs read operations (e.g., checking out code and running linting), we will set `contents: read` as the minimal required permission. This ensures the workflow adheres to the principle of least privilege while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
