### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
Potential fix for [https://github.com/Runroom/edenred_test/security/code-scanning/3](https://github.com/Runroom/edenred_test/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves testing and building the code, it only requires read access to the repository contents. We will set `contents: read` at the workflow level to apply this permission to all jobs (`test` and `build`). This ensures that the `GITHUB_TOKEN` has the minimal permissions necessary for the workflow to function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
